### PR TITLE
Prevents 'promise is undefined' error in browsers which do not support promises

### DIFF
--- a/app/initializers/css-module-route.js
+++ b/app/initializers/css-module-route.js
@@ -66,7 +66,7 @@ export function initialize() {
       let link = createStylesheetLink(this.routeName);
 
       // Create a promise to let us know when the stylesheet is loaded
-      let promise = new Promise((resolve, reject) => {
+      let promise = new Ember.RSVP.Promise((resolve, reject) => {
         // Check that the link has 'onload' and 'onerror' handlers
         if (link.hasOwnProperty('onload') && link.hasOwnProperty('onerror')) {
           link.onload = () => {


### PR DESCRIPTION
The ember-css-routes addon is preventing browsers such as IE11 from rendering the page (as in it displays just a blank white page) as the use of `new Promise` throws the error 'promise is undefined'. This pull request switches it to use embers built in promises so we don't get browser compatibility issues.
